### PR TITLE
Withdraw receipt root

### DIFF
--- a/contracts/BytesLib.sol
+++ b/contracts/BytesLib.sol
@@ -95,11 +95,17 @@ library BytesLib {
                 // the actual length of the slice.
                 let lengthmod := and(_length, 31)
 
-                let mc := add(tempBytes, lengthmod)
+                // The multiplication in the next line is necessary
+                // because when slicing multiples of 32 bytes (lengthmod == 0)
+                // the following copy loop was copying the origin's length
+                // and then ending prematurely not copying everything it should.
+                let mc := add(add(tempBytes, lengthmod), mul(0x20, iszero(lengthmod)))
                 let end := add(mc, _length)
 
                 for {
-                    let cc := add(add(_bytes, lengthmod), _start)
+                    // The multiplication in the next line has the same exact purpose
+                    // as the one above.
+                    let cc := add(add(add(_bytes, lengthmod), mul(0x20, iszero(lengthmod))), _start)
                 } lt(mc, end) {
                     mc := add(mc, 0x20)
                     cc := add(cc, 0x20)
@@ -114,11 +120,11 @@ library BytesLib {
                 mstore(0x40, and(add(mc, 31), not(31)))
             }
             //if we want a zero-length slice let's just return a zero-length array
-            /*default {
+            default {
                 tempBytes := mload(0x40)
 
                 mstore(0x40, add(tempBytes, 0x20))
-            }*/
+            }
         }
 
         return tempBytes;

--- a/contracts/RLPEncode.sol
+++ b/contracts/RLPEncode.sol
@@ -41,11 +41,22 @@ library RLPEncode {
         lenLen++;
         i *= 0x100;
       }
-      bytes memory firstByte = new bytes(1);
-      firstByte[0] = byte(offset + 55 + lenLen);
-      bytes memory second = new bytes(1);
-      second[0] = byte(L);
-      return BytesLib.concat(firstByte, second);
+			bytes memory prefix0 = getLengthBytes(offset + 55 + lenLen);
+			bytes memory prefix1 = getLengthBytes(L);
+      return BytesLib.concat(prefix0, prefix1);
+    }
+  }
+
+	function getLengthBytes(uint256 x) constant returns (bytes b) {
+		// Figure out if we need 1 or two bytes to express the length.
+		// 1 byte gets us to max 255
+		// 2 bytes gets us to max 65535 (no payloads will be larger than this)
+		uint256 nBytes = 1;
+		if (x > 255) { nBytes = 2; }
+		b = new bytes(nBytes);
+		// Encode the length and return it
+		for (uint i = 0; i < nBytes; i++) {
+      b[i] = byte(uint8(x / (2**(8*(nBytes - 1 - i)))));
     }
   }
 }

--- a/contracts/RLPEncode.sol
+++ b/contracts/RLPEncode.sol
@@ -27,6 +27,21 @@ library RLPEncode {
     return BytesLib.concat(encodeLength(encoded.length, 192), encoded);
   }
 
+	// Hack to encode nested lists. If you have a list as an item passed here, included
+	// pass = true in that index. E.g.
+	// [item, list, item] --> pass = [false, true, false]
+	function encodeListWithPasses(bytes[] memory self, bool[] pass) internal constant returns (bytes) {
+    bytes memory encoded;
+    for (uint i=0; i < self.length; i++) {
+			if (pass[i] == true) {
+				encoded = BytesLib.concat(encoded, self[i]);
+			} else {
+				encoded = BytesLib.concat(encoded, encodeItem(self[i]));
+			}
+    }
+    return BytesLib.concat(encodeLength(encoded.length, 192), encoded);
+  }
+
   // Generate the prefix for an item or the entire list based on RLP spec
   function encodeLength(uint256 L, uint256 offset) internal constant returns (bytes) {
     if (L < 56) {

--- a/contracts/Relay.sol
+++ b/contracts/Relay.sol
@@ -316,20 +316,20 @@ contract Relay {
     //   [addrs[1], [ topics[3], topics[4], topics[5], topics[6] ], data[1] ] ]
     bytes[] memory log0 = new bytes[](3);
     bytes[] memory topics0 = new bytes[](3);
-    log0[0] = BytesLib.slice(logs, 0, 32);
-    topics0[0] = BytesLib.slice(logs, 32, 32);
-    topics0[1] = BytesLib.slice(logs, 64, 32);
-    topics0[2] = BytesLib.slice(logs, 96, 32);
+    log0[0] = BytesLib.slice(logs, 0, 20);
+    topics0[0] = BytesLib.slice(logs, 20, 32);
+    topics0[1] = BytesLib.slice(logs, 52, 32);
+    topics0[2] = BytesLib.slice(logs, 84, 32);
     log0[1] = RLPEncode.encodeList(topics0);
-    log0[2] = BytesLib.slice(logs, 128, 32);
+    log0[2] = BytesLib.slice(logs, 116, 32);
     bytes[] memory log1 = new bytes[](3);
     bytes[] memory topics1 = new bytes[](3);
-    log1[0] = BytesLib.slice(logs, 0, 32);
-    topics1[0] = BytesLib.slice(logs, 32, 32);
-    topics1[1] = BytesLib.slice(logs, 64, 32);
-    topics1[2] = BytesLib.slice(logs, 96, 32);
+    log1[0] = BytesLib.slice(logs, 148, 20);
+    topics1[0] = BytesLib.slice(logs, 168, 32);
+    topics1[1] = BytesLib.slice(logs, 200, 32);
+    topics1[2] = BytesLib.slice(logs, 232, 32);
     log1[1] = RLPEncode.encodeList(topics0);
-    log1[2] = BytesLib.slice(logs, 128, 32);
+    log1[2] = BytesLib.slice(logs, 264, 32);
 
 
     // Make sure this receipt belongs to the user's tx
@@ -337,12 +337,12 @@ contract Relay {
     // within the two logs. Slice that out of the bytes array and make sure it
     // matches the proposed tx.
 
-    bytes[] memory receipt = new bytes[](1);
-    /*receipt[0] = hex"01";
-    receipt[1] = cumulativeGas;*/
-    receipt[0] = logsBloom;
+    bytes[] memory receipt = new bytes[](3);
+    receipt[0] = hex"01";
+    receipt[1] = cumulativeGas;
+    receipt[2] = logsBloom;
     /*receipt[3] = RLPEncode.encodeList(log0);*/
-    return RLPEncode.encodeList(receipt);
+    return log1[2];
 
     //
     //assert(MerklePatriciaProof.verify(RLPEncode.encodeList(receipt), path, parentNodes, receiptRoot) == true);

--- a/contracts/Relay.sol
+++ b/contracts/Relay.sol
@@ -323,7 +323,7 @@ contract Relay {
     log0[1] = RLPEncode.encodeList(topics0);
     log0[2] = BytesLib.slice(logs, 116, 32);
 
-    /*bytes[] memory log1 = new bytes[](3);
+    bytes[] memory log1 = new bytes[](3);
     bytes[] memory topics1 = new bytes[](4);
     log1[0] = BytesLib.slice(logs, 148, 20);
     topics1[0] = BytesLib.slice(logs, 168, 32);
@@ -331,31 +331,34 @@ contract Relay {
     topics1[2] = BytesLib.slice(logs, 232, 32);
     topics1[3] = BytesLib.slice(logs, 264, 32);
     log1[1] = RLPEncode.encodeList(topics1);
-    log1[2] = BytesLib.slice(logs, 296, 32);*/
+    log1[2] = BytesLib.slice(logs, 296, 32);
 
     // We need to hack around the RLPEncode library for the topics, which are
     // nested lists
-    bool[] memory passes = new bool[](3);
+    bool[] memory passes = new bool[](4);
     passes[0] = false;
     passes[1] = true;
     passes[2] = false;
+    bytes[] memory allLogs = new bytes[](2);
+    allLogs[0] = RLPEncode.encodeListWithPasses(log0, passes);
+    allLogs[1] = RLPEncode.encodeListWithPasses(log1, passes);
+    passes[0] = true;
 
-    /*bytes[] memory allLogs = new bytes[](2);
-    allLogs[0] = log0;
-    allLogs[1] = log1;*/
-
-    return RLPEncode.encodeListWithPasses(log0, passes);
 
     // Make sure this receipt belongs to the user's tx
     // TODO: Pass two indices that indicate the positions of the tx hash from
     // within the two logs. Slice that out of the bytes array and make sure it
     // matches the proposed tx.
 
-    /*bytes[] memory receipt = new bytes[](4);
+    bytes[] memory receipt = new bytes[](4);
     receipt[0] = hex"01";
     receipt[1] = cumulativeGas;
     receipt[2] = logsBloom;
-    return RLPEncode.encodeList(log0);*/
+    receipt[3] = RLPEncode.encodeListWithPasses(allLogs, passes);
+    passes[0] = false;
+    passes[1] = false;
+    passes[3] = true;
+    return RLPEncode.encodeListWithPasses(receipt, passes);
 
     //
     //assert(MerklePatriciaProof.verify(RLPEncode.encodeList(receipt), path, parentNodes, receiptRoot) == true);

--- a/contracts/Relay.sol
+++ b/contracts/Relay.sol
@@ -322,27 +322,40 @@ contract Relay {
     topics0[2] = BytesLib.slice(logs, 84, 32);
     log0[1] = RLPEncode.encodeList(topics0);
     log0[2] = BytesLib.slice(logs, 116, 32);
-    bytes[] memory log1 = new bytes[](3);
-    bytes[] memory topics1 = new bytes[](3);
+
+    /*bytes[] memory log1 = new bytes[](3);
+    bytes[] memory topics1 = new bytes[](4);
     log1[0] = BytesLib.slice(logs, 148, 20);
     topics1[0] = BytesLib.slice(logs, 168, 32);
     topics1[1] = BytesLib.slice(logs, 200, 32);
     topics1[2] = BytesLib.slice(logs, 232, 32);
-    log1[1] = RLPEncode.encodeList(topics0);
-    log1[2] = BytesLib.slice(logs, 264, 32);
+    topics1[3] = BytesLib.slice(logs, 264, 32);
+    log1[1] = RLPEncode.encodeList(topics1);
+    log1[2] = BytesLib.slice(logs, 296, 32);*/
 
+    // We need to hack around the RLPEncode library for the topics, which are
+    // nested lists
+    bool[] memory passes = new bool[](3);
+    passes[0] = false;
+    passes[1] = true;
+    passes[2] = false;
+
+    /*bytes[] memory allLogs = new bytes[](2);
+    allLogs[0] = log0;
+    allLogs[1] = log1;*/
+
+    return RLPEncode.encodeListWithPasses(log0, passes);
 
     // Make sure this receipt belongs to the user's tx
     // TODO: Pass two indices that indicate the positions of the tx hash from
     // within the two logs. Slice that out of the bytes array and make sure it
     // matches the proposed tx.
 
-    bytes[] memory receipt = new bytes[](3);
+    /*bytes[] memory receipt = new bytes[](4);
     receipt[0] = hex"01";
     receipt[1] = cumulativeGas;
     receipt[2] = logsBloom;
-    /*receipt[3] = RLPEncode.encodeList(log0);*/
-    return log1[2];
+    return RLPEncode.encodeList(log0);*/
 
     //
     //assert(MerklePatriciaProof.verify(RLPEncode.encodeList(receipt), path, parentNodes, receiptRoot) == true);

--- a/parity/boot.js
+++ b/parity/boot.js
@@ -160,7 +160,11 @@ function genConfig(name, port) {
       gasLimitBoundDivisor: "0x400",
       maximumExtraDataSize: "0x20",
       minGasLimit: "0x1312d00",
-      networkID: `0x${port.toString(16)}`
+      networkID: `0x${port.toString(16)}`,
+      "eip140Transition": "0x0",
+      "eip211Transition": "0x0",
+      "eip214Transition": "0x0",
+      "eip658Transition": "0x0"
     },
     "genesis": {
         "seal": {
@@ -177,7 +181,11 @@ function genConfig(name, port) {
       "0x0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
       "0x0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
       "0x0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
-      "0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } }
+      "0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+      "0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
+      "0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
+      "0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+      "0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } }
     }
   };
   return config;

--- a/test/relay.js
+++ b/test/relay.js
@@ -359,45 +359,23 @@ contract('Relay', (accounts) => {
       let topics = [encodedLogs[0][1], encodedLogs[1][1]];
       let data = [encodedLogs[0][2], encodedLogs[1][2]];
 
-      // console.log('rlp(topics)', rlp.encode(topics).toString('hex'))
-      // console.log('rlp(flat)', rlp.encode([ addrs[0], topics[0], data[0], addrs[1], topics[1], data[1] ]).toString('hex'))
-      // console.log('rlp(set)', rlp.encode([ [addrs[0], topics[0], data[0]], [addrs[1], topics[1], data[1]] ]).toString('hex'))
-      // console.log('relayB.address', relayB.options.address)
-      // console.log('accounts[1]', accounts[1])
-      // console.log('logs', depositReceipt.logs);
-      // console.log('encodedLogs', rProof.encodeLogs(depositReceipt.logs))
-      // console.log('rlp.encode(logs)', rlp.encode(rProof.encodeLogs(depositReceipt.logs)).toString('hex'))
-      //
-      // console.log('\nencodedReceiptTest', encodedReceiptTest.toString('hex'));
-//
-      // console.log('logs', rProof.encodeLogs(depositReceipt.logs))
-      // console.log('depositReceipt', deposit)
-      // console.log('logsBloom', depositReceipt.logsBloom)
-      // const proveReceipt = await relayA.proveReceipt(depositReceipt.cumulativeGasUsed,
-      //   depositReceipt.logsBloom, [tokenB.options.address, relayB.options.address],
-      //   [data[0], data[1], depositBlock.receiptsRoot], [topics[0][0], topics[0][1],
-      //   topics[0][2], topics[1][0], topics[1][1], topics[1][2], topics[1][3]],
-      //   receiptProof.path, receiptProof.parentNodes, { from: accounts[1], gas: 500000});
-      //
       let logsCat = `0x${addrs[0].toString('hex')}${topics[0][0].toString('hex')}`
       logsCat += `${topics[0][1].toString('hex')}${topics[0][2].toString('hex')}`
       logsCat += `${data[0].toString('hex')}${addrs[1].toString('hex')}${topics[1][0].toString('hex')}`
       logsCat += `${topics[1][1].toString('hex')}${topics[1][2].toString('hex')}`
       logsCat += `${topics[1][3].toString('hex')}${data[1].toString('hex')}`;
       // console.log('logsCat', logsCat)
-      console.log('\n\nencodedLogs', encodedLogs, '\n\n')
       const proveReceipt = await relayA.proveReceipt(logsCat, depositReceipt.cumulativeGasUsed,
         depositReceipt.logsBloom, { from: accounts[1], gas: 500000 })
-      // console.log('\nproof.value', rlp.encode(receiptProof.value).toString('hex'))
-      // console.log('topics[0][1]', topics[0][1])
-      // console.log('rlp(test)', rlp.encode(topics[0]).toString('hex'))
+      console.log('\nproof.value', rlp.encode(receiptProof.value).toString('hex'))
+
+
       console.log('\n\n\nproveReceipt', proveReceipt, '\n\n\n');
       console.log('encodedLogs[0][0]', encodedLogs[0][0].toString('hex'))
       console.log('encodedLogs[0][1]][0]', encodedLogs[0][1][0].toString('hex'))
       console.log('encodedLogs[0][1][1]', encodedLogs[0][1][1].toString('hex'))
       console.log('encodedLogs[0][1][2]', encodedLogs[0][1][2].toString('hex'))
       console.log('encodedLogs[0][2]', encodedLogs[0][2].toString('hex'))
-      console.log('rlp(encodedLogs)', rlp.encode(encodedLogs[0]).toString('hex'))
     });
 
     it('Should submit the required data and make the withdrwal', () => {

--- a/test/relay.js
+++ b/test/relay.js
@@ -339,9 +339,9 @@ contract('Relay', (accounts) => {
       // Make the transaction
       const prepWithdraw = await relayA.prepWithdraw(nonce, gasPrice, gas, deposit.v, deposit.r, deposit.s,
         [relayB.options.address, tokenB.options.address, relayA.address, tokenA.address], 5,
-        depositBlock.transactionsRoot, path, parentNodes, version, { from: accounts[1], gas: 600000 });
+        depositBlock.transactionsRoot, path, parentNodes, version, { from: accounts[1], gas: 500000 });
       console.log('prepWithdraw gas usage:', prepWithdraw.receipt.gasUsed);
-      assert(prepWithdraw.receipt.gasUsed < 600000);
+      assert(prepWithdraw.receipt.gasUsed < 500000);
     })
 
     it('Should check the pending withdrawal fields', async () => {
@@ -354,8 +354,6 @@ contract('Relay', (accounts) => {
     it('Should prove the state root', async () => {
       // Get the receipt proof
       const receiptProof = await rProof.buildProof(depositReceipt, depositBlockSlim, web3B);
-      console.log('deposit', deposit)
-      console.log('receiptProof', receiptProof)
       const path = ensureByte(rlp.encode(receiptProof.path).toString('hex'));
       const parentNodes = ensureByte(rlp.encode(receiptProof.parentNodes).toString('hex'));
 
@@ -366,8 +364,6 @@ contract('Relay', (accounts) => {
       const encodedReceiptValue = rlp.encode(receiptProof.value);
 
       assert(encodedReceiptTest.equals(encodedReceiptValue) == true);
-
-      console.log('encodedLogs', encodedLogs)
       let addrs = [encodedLogs[0][0], encodedLogs[1][0]];
       let topics = [encodedLogs[0][1], encodedLogs[1][1]];
       let data = [encodedLogs[0][2], encodedLogs[1][2]];
@@ -377,21 +373,11 @@ contract('Relay', (accounts) => {
       logsCat += `${data[0].toString('hex')}${addrs[1].toString('hex')}${topics[1][0].toString('hex')}`
       logsCat += `${topics[1][1].toString('hex')}${topics[1][2].toString('hex')}`
       logsCat += `${topics[1][3].toString('hex')}${data[1].toString('hex')}`;
-      console.log('topics1data', data[1].toString('hex'))
-      console.log('encodedLogs', encodedLogs)
-      console.log('relayA', relayA.address);
-      console.log('relayB', relayB.options.address);
-      console.log('tokenA', tokenA.address);
-      console.log('tokenB', tokenB.options.address);
-      console.log('accounts[1]', accounts[1])
       const proveReceipt = await relayA.proveReceipt(logsCat, depositReceipt.cumulativeGasUsed,
         depositReceipt.logsBloom, depositBlock.receiptsRoot, path, parentNodes,
-        { from: accounts[1], gas: 1000000 })
-      console.log('proveReceipt', proveReceipt);
+        { from: accounts[1], gas: 500000 })
 
-      // console.log('proveReceipt gas usage', proveReceipt.receipt.gasUsed);
-      // assert(proveReceipt.receipt.gasUsed < 1000000);
-
+      console.log('proveReceipt gas usage:', proveReceipt.receipt.gasUsed);
     });
 
     it('Should submit the required data and make the withdrwal', () => {

--- a/test/relay.js
+++ b/test/relay.js
@@ -384,17 +384,20 @@ contract('Relay', (accounts) => {
       logsCat += `${data[0].toString('hex')}${addrs[1].toString('hex')}${topics[1][0].toString('hex')}`
       logsCat += `${topics[1][1].toString('hex')}${topics[1][2].toString('hex')}`
       logsCat += `${topics[1][3].toString('hex')}${data[1].toString('hex')}`;
-      console.log('logsCat', logsCat)
+      // console.log('logsCat', logsCat)
+      console.log('\n\nencodedLogs', encodedLogs, '\n\n')
       const proveReceipt = await relayA.proveReceipt(logsCat, depositReceipt.cumulativeGasUsed,
         depositReceipt.logsBloom, { from: accounts[1], gas: 500000 })
-      console.log('\nproof.value', rlp.encode(receiptProof.value).toString('hex'))
+      // console.log('\nproof.value', rlp.encode(receiptProof.value).toString('hex'))
       // console.log('topics[0][1]', topics[0][1])
       // console.log('rlp(test)', rlp.encode(topics[0]).toString('hex'))
-      console.log('\nproveReceipt', proveReceipt);
-      console.log('gasUsed', depositReceipt.cumulativeGasUsed.toString(16));
-      console.log('\ndepositReceipt.logsBloom', depositReceipt.logsBloom);
-      const tmp = ['0x1', depositReceipt.cumulativeGasUsed, depositReceipt.logsBloom];
-      console.log('rlp(test)', rlp.encode(tmp).toString('hex'))
+      console.log('\n\n\nproveReceipt', proveReceipt, '\n\n\n');
+      console.log('encodedLogs[0][0]', encodedLogs[0][0].toString('hex'))
+      console.log('encodedLogs[0][1]][0]', encodedLogs[0][1][0].toString('hex'))
+      console.log('encodedLogs[0][1][1]', encodedLogs[0][1][1].toString('hex'))
+      console.log('encodedLogs[0][1][2]', encodedLogs[0][1][2].toString('hex'))
+      console.log('encodedLogs[0][2]', encodedLogs[0][2].toString('hex'))
+      console.log('rlp(encodedLogs)', rlp.encode(encodedLogs[0]).toString('hex'))
     });
 
     it('Should submit the required data and make the withdrwal', () => {

--- a/test/relay.js
+++ b/test/relay.js
@@ -329,23 +329,20 @@ contract('Relay', (accounts) => {
       assert(encodedTest == encodedValue, 'Tx RLP encoding incorrect');
 
       // Check the proof in JS first
-      const checkpoint = txProof.verifyTx(proof);
+      const checkpoint = txProof.verify(proof, 4);
       assert(checkpoint === true);
 
       // Get the network version
       const version = parseInt(deposit.chainId);
 
       // Get the receipt proof
-      // const tmp = await web3B.eth.getTransactionReceipt(depositBlockSlim.transactions[0]);
-      // console.log('is there a tx receipt?', tmp)
       const receiptProof = await rProof.buildProof(depositReceipt, depositBlockSlim, web3B);
-      console.log('receiptProof', receiptProof);
-
+      const checkpoint2 = txProof.verify(receiptProof, 5);
+      console.log('value', rlp.encode(receiptProof.value).toString('hex'))
       // Make the transaction
       const test = await relayA.prepWithdraw(nonce, gasPrice, gas, deposit.v, deposit.r, deposit.s,
-        [deposit.to, tokenB.options.address, relayA.address], [5, depositReceipt.gasUsed],
-        [depositBlock.transactionsRoot, depositReceipt.root],
-        path, parentNodes, version, { from: accounts[1], gas: 500000 });
+        [deposit.to, tokenB.options.address, relayA.address], 5,
+        depositBlock.transactionsRoot, path, parentNodes, version, { from: accounts[1], gas: 500000 });
       assert(test.receipt.gasUsed < 500000);
       console.log('prepWithdraw gas usage:', test.receipt.gasUsed);
     })

--- a/test/relay.js
+++ b/test/relay.js
@@ -394,8 +394,7 @@ contract('Relay', (accounts) => {
       console.log('gasUsed', depositReceipt.cumulativeGasUsed.toString(16));
       console.log('\ndepositReceipt.logsBloom', depositReceipt.logsBloom);
       const tmp = ['0x1', depositReceipt.cumulativeGasUsed, depositReceipt.logsBloom];
-      // console.log('rlp(test)', rlp.encode(tmp).toString('hex'))
-      console.log('rlp(bloom)', rlp.encode([depositReceipt.logsBloom]).toString('hex'))
+      console.log('rlp(test)', rlp.encode(tmp).toString('hex'))
     });
 
     it('Should submit the required data and make the withdrwal', () => {

--- a/test/util/receiptProof.js
+++ b/test/util/receiptProof.js
@@ -7,11 +7,11 @@ const async = require('async');
 const EthereumBlock = require('ethereumjs-block/from-rpc');
 
 exports.buildProof = buildProof;
+exports.encodeLogs = encodeLogs;
 
 function buildProof(receipt, block, web3) {
   return new Promise((resolve, reject) => {
     var receiptsTrie = new Trie();
-    console.log('receipt', receipt)
     Promise.map(block.transactions, (siblingTxHash) => {
       return web3.eth.getTransactionReceipt(siblingTxHash)
     })
@@ -37,7 +37,6 @@ function buildProof(receipt, block, web3) {
 }
 
 var putReceipt = (siblingReceipt, receiptsTrie, cb2) => {//need siblings to rebuild trie
-  console.log('putting receipt', siblingReceipt)
   var path = siblingReceipt.transactionIndex
   var cummulativeGas = numToBuf(siblingReceipt.cumulativeGasUsed)
   var bloomFilter = strToBuf(siblingReceipt.logsBloom)
@@ -45,7 +44,6 @@ var putReceipt = (siblingReceipt, receiptsTrie, cb2) => {//need siblings to rebu
   var rawReceipt;
   if (siblingReceipt.status !== undefined && siblingReceipt.status != null) {
     var status = strToBuf(siblingReceipt.status);
-    console.log('rlp set of logs', rlp.encode([setOfLogs]).toString('hex'))
     rawReceipt = rlp.encode([status, cummulativeGas, bloomFilter, setOfLogs]);
   } else {
     var postTransactionState = strToBuf(siblingReceipt.root)
@@ -56,7 +54,7 @@ var putReceipt = (siblingReceipt, receiptsTrie, cb2) => {//need siblings to rebu
     error != null ? cb2(error, null) : cb2(error, true)
   })
 }
-var encodeLogs = (input) => {
+function encodeLogs(input) {
   var logs = []
   for (var i = 0; i < input.length; i++) {
     var address = strToBuf(input[i].address);

--- a/test/util/receiptProof.js
+++ b/test/util/receiptProof.js
@@ -45,6 +45,7 @@ var putReceipt = (siblingReceipt, receiptsTrie, cb2) => {//need siblings to rebu
   var rawReceipt;
   if (siblingReceipt.status !== undefined && siblingReceipt.status != null) {
     var status = strToBuf(siblingReceipt.status);
+    console.log('rlp set of logs', rlp.encode([setOfLogs]).toString('hex'))
     rawReceipt = rlp.encode([status, cummulativeGas, bloomFilter, setOfLogs]);
   } else {
     var postTransactionState = strToBuf(siblingReceipt.root)

--- a/test/util/receiptProof.js
+++ b/test/util/receiptProof.js
@@ -1,0 +1,86 @@
+// Merkle-Patricia proof for a transaction receipt.
+// Modified from eth-proof
+const Promise = require('bluebird').Promise;
+const Trie = require('merkle-patricia-tree');
+const rlp = require('rlp');
+const async = require('async');
+
+exports.buildProof = buildProof;
+
+function buildProof(receipt, block, web3) {
+  return new Promise((resolve, reject) => {
+    var receiptsTrie = new Trie();
+    console.log('receipt', receipt)
+    Promise.map(block.transactions, (siblingTxHash) => {
+      return web3.eth.getTransactionReceipt(siblingTxHash)
+    })
+    .map((siblingReceipt) => {
+      putReceipt(siblingReceipt, receiptsTrie);
+      return;
+    })
+    .then(() => {
+      return resolve(true);
+      // receiptsTrie.findPath(rlp.encode(receipt.transactionIndex), (e,rawReceiptNode,remainder,stack) => {
+      //   var prf = {
+      //     blockHash: Buffer.from(receipt.blockHash.slice(2),'hex'),
+      //     header:    getRawHeader(block),
+      //     parentNodes:     rawStack(stack),
+      //     path:      rlp.encode(receipt.transactionIndex),
+      //     value:     rlp.decode(rawReceiptNode.value)
+      //   }
+      //   return resolve(prf)
+      // })
+    })
+    .catch((err) => { return reject(err); });
+  })
+}
+
+var putReceipt = (siblingReceipt, receiptsTrie, cb2) => {//need siblings to rebuild trie
+  console.log('putting receipt', siblingReceipt)
+  var path = siblingReceipt.transactionIndex
+  var postTransactionState = strToBuf(siblingReceipt.root)
+  var cummulativeGas = numToBuf(siblingReceipt.cumulativeGasUsed)
+  var bloomFilter = strToBuf(siblingReceipt.logsBloom)
+  var setOfLogs = encodeLogs(siblingReceipt.logs)
+  var rawReceipt = rlp.encode([postTransactionState,cummulativeGas,bloomFilter,setOfLogs])
+
+  receiptsTrie.put(rlp.encode(path), rawReceipt, function (error) {
+    error != null ? cb2(error, null) : cb2(error, true)
+  })
+}
+var encodeLogs = (input) => {
+  var logs = []
+  for (var i = 0; i < input.length; i++) {
+    var address = strToBuf(input[i].address);
+    var topics = input[i].topics.map(strToBuf)
+    var data = Buffer.from(input[i].data.slice(2),'hex')
+    logs.push([address, topics, data])
+  }
+  return logs
+}
+var rawStack = (input) => {
+  output = []
+  for (var i = 0; i < input.length; i++) {
+    output.push(input[i].raw)
+  }
+  return output
+}
+var getRawHeader = (_block) => {
+  if(typeof _block.difficulty != 'string'){
+    _block.difficulty = '0x' + _block.difficulty.toString(16)
+  }
+  var block = new EthereumBlock(_block)
+  return block.header.raw
+}
+var squanchTx = (tx) => {
+  tx.gasPrice = '0x' + tx.gasPrice.toString(16)
+  tx.value = '0x' + tx.value.toString(16)
+  return tx;
+}
+var strToBuf = (input)=>{
+  if(input.slice(0,2) == "0x"){
+    return Buffer.from(byteable(input.slice(2)), "hex")
+  }else{
+    return Buffer.from(byteable(input), "hex")
+  }
+}

--- a/test/util/txProof.js
+++ b/test/util/txProof.js
@@ -56,13 +56,11 @@ function verify(proof, j) {
   const blockHash = proof.blockHash;
   const txRoot = header[j]; // txRoot is the 4th item in the header Array
   try{
-    console.log('parentNodes', parentNodes)
     var currentNode;
     var len = parentNodes.length;
     var rlpTxFromPrf = parentNodes[len - 1][parentNodes[len - 1].length - 1];
     var nodeKey = txRoot;
     var pathPtr = 0;
-    console.log()
     for (var i = 0 ; i < len ; i++) {
       currentNode = parentNodes[i];
       const encodedNode = Buffer.from(sha3(rlp.encode(currentNode)),'hex');

--- a/test/util/txProof.js
+++ b/test/util/txProof.js
@@ -15,7 +15,7 @@ const async = require('async');
 const sha3 = require('js-sha3').keccak256;
 
 exports.build = build;
-exports.verifyTx = verifyTx;
+exports.verify = verify;
 
 function build(tx, block) {
   return new Promise((resolve, reject) => {
@@ -47,20 +47,22 @@ function build(tx, block) {
 // From eth-proof (VerifyProof.trieValue)
 // Checks that the path of the tx (value) is correct
 // `value` is rlp decoded
-function verifyTx(proof) {
+// `i` is the index of the root in the header: 4 = tx, 5 = receipt
+function verify(proof, j) {
   const path  = proof.path.toString('hex');
   const value = proof.value;
   const parentNodes = proof.parentNodes;
   const header = proof.header;
   const blockHash = proof.blockHash;
-  const txRoot = header[4]; // txRoot is the 4th item in the header Array
+  const txRoot = header[j]; // txRoot is the 4th item in the header Array
   try{
+    console.log('parentNodes', parentNodes)
     var currentNode;
     var len = parentNodes.length;
     var rlpTxFromPrf = parentNodes[len - 1][parentNodes[len - 1].length - 1];
     var nodeKey = txRoot;
     var pathPtr = 0;
-
+    console.log()
     for (var i = 0 ; i < len ; i++) {
       currentNode = parentNodes[i];
       const encodedNode = Buffer.from(sha3(rlp.encode(currentNode)),'hex');


### PR DESCRIPTION
This adds a receipt checker to the `prepWithdraw` function. This is required because the tx data alone does not prove that the tx actually got applied to the bridged blockchain.